### PR TITLE
修复tag collector出现encoding error报错的问题

### DIFF
--- a/pixiv_crawler/collector/selectors.py
+++ b/pixiv_crawler/collector/selectors.py
@@ -2,7 +2,7 @@ import json
 import re
 from typing import List, Set
 
-from pyquery import PyQuery
+from bs4 import BeautifulSoup
 from requests.models import Response
 from utils import printError, writeFailLog
 
@@ -16,11 +16,17 @@ def selectTag(response: Response) -> List[str]:
         List[str]: tags
     """
     result = re.search("artworks/(\d+)", response.url)
-    printError(result is None, "bad response in selectTag")
+    if result is None:
+        printError(True, f"bad response in selectTag for URL: {response.url}")
+        return []
+
     illust_id = result.group(1)
     content = json.loads(
-        PyQuery(response.text).find(
-            "#meta-preload-data").attr("content"))
+        BeautifulSoup(response.text, 'html.parser')
+        .find(id="meta-preload-data")
+        .get("content")
+        )
+
     return [
         tag["translation"]["en"] if "translation" in tag else tag["tag"]
         for tag in content["illust"][illust_id]["tags"]["tags"]

--- a/pixiv_crawler/collector/selectors.py
+++ b/pixiv_crawler/collector/selectors.py
@@ -16,16 +16,14 @@ def selectTag(response: Response) -> List[str]:
         List[str]: tags
     """
     result = re.search("artworks/(\d+)", response.url)
-    if result is None:
-        printError(True, f"bad response in selectTag for URL: {response.url}")
-        return []
+    assert result is not None, f"bad response in selectTag for URL: {response.url}"
 
     illust_id = result.group(1)
     content = json.loads(
         BeautifulSoup(response.text, 'html.parser')
         .find(id="meta-preload-data")
         .get("content")
-        )
+    )
 
     return [
         tag["translation"]["en"] if "translation" in tag else tag["tag"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4==4.12.3
 charset-normalizer==3.0.1
 cssselect==1.2.0
 idna==3.4
@@ -5,4 +6,3 @@ lxml==4.9.2
 requests==2.28.2
 tqdm==4.64.1
 urllib3==1.26.14
-bs4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ charset-normalizer==3.0.1
 cssselect==1.2.0
 idna==3.4
 lxml==4.9.2
-pyquery==2.0.0
 requests==2.28.2
 tqdm==4.64.1
 urllib3==1.26.14
+bs4


### PR DESCRIPTION
如果启用了`WITH_TAG`, 那么collect tag的过程中就会报错:
`
encoding error : input conversion failed due to input error, bytes 0x21 0x00 0x00 0x00
encoding error : input conversion failed due to input error, bytes 0x44 0x00 0x00 0x00
I/O error : encoder error
`
<img width="1432" alt="image" src="https://github.com/CWHer/PixivCrawler/assets/49088507/a43dff95-5f4e-46ca-ae5d-a41501c9cf26">


找了半天,**发现**是`pixiv_crawler/collector/selectors.py`中的
` python
PyQuery(response.text).find(
            "#meta-preload-data").attr("content"))
`

这段代码出现了问题, `PyQuery`不知道为什么解析一些tag的时候会出现
`encoding error : input conversion failed due to input error, bytes 0x21 0x00 0x00 0x00`这样的编码错误,

而如果将`PyQuery`换成`BeautifulSoup`来解析html文件,这个问题就解决了

并且我发现`PyQuery`这个库,只有这个地方用到了,所以我将其从`requirements.txt`中删除了,并加入安装了`bs4`库.
我看issue里有多个人也出现了这个问题, 换个库来解析这样应该能够彻底解决这个问题(?)
更换后的效果如下:
<img width="1435" alt="image" src="https://github.com/CWHer/PixivCrawler/assets/49088507/743f7f2f-3a80-4e13-b538-6175f8640ab1">



我的**测试环境**为:
Python 3.10.14
MacOS 14.5 (Sonoma) M1 Silicon